### PR TITLE
SEPT-96 :  1on1の予約を実施日の近い順に表示する

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -56,7 +56,7 @@ class ProfileController extends Controller
 
         $urls = $this->urlService->findUrls($profile, config('url.types'));
 
-        $upcomingReservations = $this->reservationService->getUpcomingReservationsByUser($user);
+        $upcomingReservations = $this->reservationService->getUpcomingReservationsByUser($user)->sortBy('date');
 
         list($userCareer, $careers, $userPurposes, $purposes, $userSkills, $skills, $mentors, $application,
             $appliedMentor)

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -56,7 +56,7 @@ class ProfileController extends Controller
 
         $urls = $this->urlService->findUrls($profile, config('url.types'));
 
-        $upcomingReservations = $this->reservationService->getUpcomingReservationsByUser($user)->sortBy('date');
+        $upcomingReservations = $this->reservationService->getUpcomingReservationsByUser($user);
 
         list($userCareer, $careers, $userPurposes, $purposes, $userSkills, $skills, $mentors, $application,
             $appliedMentor)

--- a/app/Services/ReservationService.php
+++ b/app/Services/ReservationService.php
@@ -32,7 +32,7 @@ class ReservationService
 
     public function getUpcomingReservationsByUser($user)
     {
-        return $this->reservationRepository->getUpcomingByUser($user);
+        return $this->reservationRepository->getUpcomingByUser($user)->sortBy('date');
     }
 
     public function store(StoreReservationRequest $request)


### PR DESCRIPTION
## チケットへのリンク

*https://team-september.atlassian.net/jira/software/projects/SEPT/boards/2?selectedIssue=SEPT-96

## やったこと

* ProfileControllerを修正、日付の昇順で1on1予約を表示できるようにした


## できるようになること（ユーザ目線）

* 1on1の日程が見やすくなる
## 動作確認

* ローカルで確認済み。3人からの予約を行い、1on1実施日を適当に入れました。その後メンターページで1on1日程が昇順に表示されることを確認

*Before*
![スクリーンショット 2021-08-07 18 38 05](https://user-images.githubusercontent.com/53119949/128595950-23cf209c-8636-403a-b12d-5872e59384b7.png)

*After*
![スクリーンショット 2021-08-07 17 26 08](https://user-images.githubusercontent.com/53119949/128595962-ca676d8e-974f-4a05-b207-c718050a0adf.png)


## その他

* テストの書き方がわかりません。ぜひアドバイスをください！！
* テストを書きたい気持ちはあります。しかし、方針が見えません。